### PR TITLE
Standardize grammar to expression style

### DIFF
--- a/design/grammar.md
+++ b/design/grammar.md
@@ -1,83 +1,84 @@
 ## Integers
-```python
+```ebnf
 integer ::= [-]?[1-9][0-9]*
 ```
 
 ## Identifiers
-```python
+```ebnf
 identifier ::= [a-z][a-zA-Z0-9_]*
 ```
 
 ## The `point` keyword
-```python
+```ebnf
 point ::= "point"
 ```
 
 ## Operators
-```python
+```ebnf
 op ::= "+" | "-" | "/" | "*"
 ```
 
 ## Expressions
 
 ### Integer expressions
-```python
-IntExp ::= 
+```ebnf
+IExp ::= 
     | integer
-    | "(" IntExp ")"
-    | IntExp op IExp
+    | identifier
+    | "(" IExp ")"
+    | IExp op IExp
 ```
 
 ### Vector expressions
-```python
-VecExp ::= 
+```ebnf
+VExp ::= 
     | Vector
-    | "(" VecExp ")"
-    | VecExp op VExp
-    | IntExp "*" VecExp
-    | VecExp "*" IntExp
+    | identifier
+    | "(" VExp ")"
+    | VExp op VExp
+    | IExp "*" VExp
+    | VExp "*" IExp
 ```
 
 ## Vectors
-```python
-Vector ::= "(" IntExp "," IntExp ")"
+```ebnf
+Vector ::= "(" IExp "," IExp ")"
 ```
 
 ## Shapes
 ### Unsized shape
-```python
-UShape ::= "{" ( (identifier | Shape | point) "at" VecExp )+ "}"
+```ebnf
+UShape ::= "{" ( (identifier | Shape | point) "at" VExp )+ "}"
 ```
 
 ### Size vector
-```python
-SVector ::= "[" IntExp "," IntExp "]"
+```ebnf
+SVector ::= "[" IExp "," IExp "]"
 ```
 
 ### Sized shape
-```python
+```ebnf
 SShape ::= SVector UShape
 ```
 
 ### General shape
-```python
+```ebnf
 Shape ::= UShape | SShape
 ```
 
 ## Variable declaration
-```python
-Declaration ::= "var" identifier "=" ( IntExp | VecExp | Shape )
+```ebnf
+Declaration ::= "var" identifier "=" ( IExp | VExp | Shape )
 ```
-
 
 ## Grid
 ### Grid shape (forced to have size vector)
-```python
-GridDef ::= (Declaration)* "grid" SShape
+```ebnf
+GridDef ::= (Declaration)* | (Declaration)* "grid" SShape
 ```
 
 ## Progam (root)
-```python
+```ebnf
 Program ::= GridDef
 ```
 

--- a/design/grammar.md
+++ b/design/grammar.md
@@ -16,18 +16,18 @@
 ```
 IntExp ::= 
     | int
-    | "(" IExp ")"
-    | IExp op IExp
+    | "(" IntExp ")"
+    | IntExp op IExp
 ```
 
 ### Vector expressions
 ```
 VecExp ::= 
     | Vector
-    | "(" VExp ")"
-    | VExp op VExp
-    | IExp "*" VExp
-    | VExp "*" IExp
+    | "(" VecExp ")"
+    | VecExp op VExp
+    | IntExp "*" VecExp
+    | VecExp "*" IntExp
 ```
 
 ## Vectors
@@ -37,7 +37,7 @@ Vector ::= "(" IntExp "," IntExp ")"
 
 ## Shapes
 ### Unsized shape
-`UShape ::= "{" ( (identifier | Shape | point) "at" VExp )+ "}"`
+`UShape ::= "{" ( (identifier | Shape | point) "at" VecExp )+ "}"`
 
 ### Size vector
 `SVector ::= "[" IntExp "," IntExp "]"`
@@ -57,7 +57,7 @@ Declaration ::= "var" identifier "=" ( IntExp | VecExp | Shape )
 
 ## Grid
 ### Grid shape (forced to have size vector)
-`GridDef ::= (Declaration)* SShape`
+`GridDef ::= (Declaration)* "grid" SShape`
 
 ## Progam (root)
 `Program -> GridDef`

--- a/design/grammar.md
+++ b/design/grammar.md
@@ -10,7 +10,7 @@ identifier ::= [a-z][a-zA-Z0-9_]*
 
 ## The `point` keyword
 ```python
-point -> "point"
+point ::= "point"
 ```
 
 ## Operators
@@ -78,7 +78,7 @@ GridDef ::= (Declaration)* "grid" SShape
 
 ## Progam (root)
 ```python
-Program -> GridDef
+Program ::= GridDef
 ```
 
 #### Note

--- a/design/grammar.md
+++ b/design/grammar.md
@@ -1,27 +1,35 @@
 ## Integers
-`int ::= [-]?[1-9][0-9]*`
+```python
+integer ::= [-]?[1-9][0-9]*
+```
 
 ## Identifiers
-`identifier ::= [a-z][a-zA-Z0-9_]*`
+```python
+identifier ::= [a-z][a-zA-Z0-9_]*
+```
 
 ## The `point` keyword
-`point -> "point"`
+```python
+point -> "point"
+```
 
 ## Operators
-`op ::= "+" | "-" | "/" | "*"`
+```python
+op ::= "+" | "-" | "/" | "*"
+```
 
 ## Expressions
 
 ### Integer expressions
-```
+```python
 IntExp ::= 
-    | int
+    | integer
     | "(" IntExp ")"
     | IntExp op IExp
 ```
 
 ### Vector expressions
-```
+```python
 VecExp ::= 
     | Vector
     | "(" VecExp ")"
@@ -31,36 +39,47 @@ VecExp ::=
 ```
 
 ## Vectors
-```
+```python
 Vector ::= "(" IntExp "," IntExp ")"
 ```
 
 ## Shapes
 ### Unsized shape
-`UShape ::= "{" ( (identifier | Shape | point) "at" VecExp )+ "}"`
+```python
+UShape ::= "{" ( (identifier | Shape | point) "at" VecExp )+ "}"
+```
 
 ### Size vector
-`SVector ::= "[" IntExp "," IntExp "]"`
+```python
+SVector ::= "[" IntExp "," IntExp "]"
+```
 
 ### Sized shape
-`SShape ::= SVector UShape`
+```python
+SShape ::= SVector UShape
+```
 
 ### General shape
-`Shape ::= UShape | SShape`
-
+```python
+Shape ::= UShape | SShape
+```
 
 ## Variable declaration
-```
+```python
 Declaration ::= "var" identifier "=" ( IntExp | VecExp | Shape )
 ```
 
 
 ## Grid
 ### Grid shape (forced to have size vector)
-`GridDef ::= (Declaration)* "grid" SShape`
+```python
+GridDef ::= (Declaration)* "grid" SShape
+```
 
 ## Progam (root)
-`Program -> GridDef`
+```python
+Program -> GridDef
+```
 
 #### Note
 *`Shape` and `Declaration`do **not*** allow brace-less declarations of one-line

--- a/design/grammar.md
+++ b/design/grammar.md
@@ -1,33 +1,67 @@
+## Integers
+`int ::= [-]?[1-9][0-9]*`
+
+## Identifiers
+`identifier ::= [a-z][a-zA-Z0-9_]*`
+
+## The `point` keyword
+`point -> "point"`
+
+## Operators
+`op ::= "+" | "-" | "/" | "*"`
+
+## Expressions
+
+### Integer expressions
 ```
-int -> [-]?[1-9][0-9]*
-
-//Point is a reserved keyword equiv. to [(0, 0)]
-identifier ->
-  [a-z][a-zA-Z0-9_]*
-
-pointIdent -> "Point"
-
-Factor = int | identifier | Vector | pointIdent
-
-operator -> "+" | "-" | "/" | "*"
-
-Expression ->
-           Factor
-           | Factor operator Expression
-           | Factor operator '('Expression')'
-
-Vector ->
-         "(" AOperation "," AOperation ")"
-         | AOperation
-
-Shape -> "{" ((identifier | Shape) "at" Vector)+ "}"
-
-Definition -> "var" identifier "=" (
-           (Vector | identifier)? Shape
-           | AOperation
-)
-
-Griddef -> Definition | Definition Griddef
-
-Program -> Griddef
+IntExp ::= 
+    | int
+    | "(" IExp ")"
+    | IExp op IExp
 ```
+
+### Vector expressions
+```
+VecExp ::= 
+    | Vector
+    | "(" VExp ")"
+    | VExp op VExp
+    | IExp "*" VExp
+    | VExp "*" IExp
+```
+
+## Vectors
+```
+Vector ::= "(" IntExp "," IntExp ")"
+```
+
+## Shapes
+### Unsized shape
+`UShape ::= "{" ( (identifier | Shape | point) "at" VExp )+ "}"`
+
+### Size vector
+`SVector ::= "[" IntExp "," IntExp "]"`
+
+### Sized shape
+`SShape ::= SVector UShape`
+
+### General shape
+`Shape ::= UShape | SShape`
+
+
+## Variable declaration
+```
+Declaration ::= "var" identifier "=" ( IntExp | VecExp | Shape )
+```
+
+
+## Grid
+### Grid shape (forced to have size vector)
+`GridDef ::= (Declaration)* SShape`
+
+## Progam (root)
+`Program -> GridDef`
+
+#### Note
+*`Shape` and `Declaration`do **not*** allow brace-less declarations of one-line
+shapes in this grammar (I vote let's move this nice-to-have for later)*


### PR DESCRIPTION
Go to `Files changed` and click `View File` to view the actual Markdown file rendered

- Formatted the Markdown nicely
- Switched the grammar to a more standard (from what I've seen) expression style
- Added the concept of an `UShape` and `SShape` to differentiate unsized/sized shapes and be able to use `SShape` as the element of `GridDef`